### PR TITLE
Fix to download jars and Detect deprecated parameters

### DIFF
--- a/src/hub_load/download-packages.sh
+++ b/src/hub_load/download-packages.sh
@@ -13,11 +13,10 @@ mkdir -p $WORKDIR/jars
 # Otherwise, this script will pull down a jars.zip from S3 and unpack it to populate the jars directory
 # on the image by running this script in the docker build
 #
-if [ ! -d jars ]; then
-	echo "Downloading and unpacking jars.zip from S3"
-	wget https://bds-sa-data-files.s3.us-east-2.amazonaws.com/jars.zip
-	unzip jars.zip
-	echo "Removing jars.zip now that we have unzipped it"
-	rm jars.zip
-fi
+echo "Downloading and unpacking jars.zip from S3"
+wget https://bds-sa-data-files.s3.us-east-2.amazonaws.com/jars.zip
+unzip jars.zip
+echo "Removing jars.zip now that we have unzipped it"
+rm jars.zip
+
 

--- a/src/hub_load/submit_scans.sh
+++ b/src/hub_load/submit_scans.sh
@@ -39,7 +39,7 @@ cd $WORKDIR
 # Defaults
 #
 BD_TIMEOUT=${BD_TIMEOUT:-120}
-API_TIMEOUT=${API_TIMEOUT:-300000}
+API_TIMEOUT=${API_TIMEOUT:-300}
 MAX_SCANS=${MAX_SCANS:-10}
 MAX_CODELOCATIONS=${MAX_CODELOCATIONS:-1}
 MAX_COMPONENTS=${MAX_COMPONENTS:-400}
@@ -176,9 +176,9 @@ do
       DETECT_OPTIONS="${DETECT_OPTIONS} --detect.project.name=${project_name} --detect.project.version.name=${v}"
       DETECT_OPTIONS="${DETECT_OPTIONS} --detect.code.location.name=${cl_name}"
       DETECT_OPTIONS="${DETECT_OPTIONS} --blackduck.trust.cert=true"
-      DETECT_OPTIONS="${DETECT_OPTIONS} --detect.api.timeout=${API_TIMEOUT}"
+      DETECT_OPTIONS="${DETECT_OPTIONS} --detect.report.timeout=${API_TIMEOUT}"
       DETECT_OPTIONS="${DETECT_OPTIONS} --blackduck.timeout=${BD_TIMEOUT}"
-      DETECT_OPTIONS="${DETECT_OPTIONS} --detect.blackduck.signature.scanner.parallel.processors=-1"
+      DETECT_OPTIONS="${DETECT_OPTIONS} --detect.parallel.processors=-1"
       DETECT_OPTIONS="${DETECT_OPTIONS} --detect.tools=SIGNATURE_SCAN"
       DETECT_OPTIONS="${DETECT_OPTIONS} --detect.source.path=${project_name}/${cl_name}"
       if [ "${SYNCHRONOUS_SCANS}" == "yes" ]; then


### PR DESCRIPTION
Download jars was not downloading the jars and so hub-load was failing as no jars were available to scan.
Detect was failing due to deprecated parameters being used that are forcing Detect failure.  Note api.timeout was in milliseconds and report.timeout is in seconds.