### PR TITLE
Remove MACOS folder with jar extension types that are being included …

### DIFF
--- a/src/hub_load/download-packages.sh
+++ b/src/hub_load/download-packages.sh
@@ -16,6 +16,7 @@ mkdir -p $WORKDIR/jars
 echo "Downloading and unpacking jars.zip from S3"
 wget https://bds-sa-data-files.s3.us-east-2.amazonaws.com/jars.zip
 unzip jars.zip
+rm -rf __MACOSX
 echo "Removing jars.zip now that we have unzipped it"
 rm jars.zip
 


### PR DESCRIPTION
…in the scan but are not actually jars