### PR TITLE
Insecure curl, Updating deprecated params and snippet matching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ Container will look for the following environment variables. Default values coul
 | ----------------- | ------------------------------------------------------------ |
 | BD_HUB_URL        | The Black Duck URL (None)                                    |
 | API_TOKEN         | An API token with sufficient rights to perform scans and create project-versions(None) |
-| API_TIMEOUT       | The Synopsys detect api timeout value (300000ms). This value is passed to --detect.api.timeout on Synopsys detect |
-| BD_TIMEOUT        | The detect connection timeout (120s). This value is passed to --blackduck.timeout on Synopsys detect |
+| API_TIMEOUT       | The Synopsys detect timeout value (300000ms). This value is passed to --detect.timeout on Synopsys detect |
 | MAX_SCANS         | Maximum number of scans to perform before quitting (10)      |
 | MAX_CODELOCATIONS | Maximum number of code locations per version (1)             |
 | MIN_COMPONENTS    | Minimum number of randomly selected components (100)         |
@@ -29,6 +28,8 @@ Container will look for the following environment variables. Default values coul
 | SYNCHRONOUS_SCANS | If 'yes' will pass --detect.wait.for.results=true to Detect, otherwise do asynchronous scan assuming FAIL_ON_SEVERITIES is not passed (yes) |
 | FAIL_ON_SEVERITIES | If passed in will do a policy check for the specified severity to force detect to wait for scan processing to finish |
 | DETECT_VERSION    | The Detect Version to use, you can specify the version e.g. 6.5.0 or if omitted will use the latest (LATEST) |
+| INSECURE_CURL     | Whether to use CURL in --insecure mode for Detect and downloading Detect (no). Default is 'no' and to enable set value to 'yes' |
+| SNIPPET_MATCHING_MODE | By default this in 'NONE' but specifying a different value will pass to --detect.blackduck.signature.scanner.snippet.matching in Detect. |
 
 ### Non-interactive invocation
 
@@ -114,6 +115,17 @@ docker build -t <container tag> .
 Note: Build  process will download archives listed in hub-load/src/packagelist. This will result in a container ~5GB in size. 
 
 # Releases
+
+- Mar 22, 2021
+  - Updated detect.timeout parameter due to old options being deprecated
+  - Added INSECURE_CURL option to pass --insecure to curl inside the script and within Synopsys Detect.  By default this is 'no'.
+  - Added SNIPPET_MATCHING_MODE to make enabling snippet scanning during the load test.  However it should be noted that this will massively increase the load as most customers do not snippet scan for every scan like this.
+  
+- Mar 8, 2021
+  - Added FAIL_ON_SEVERITIES to make it possible to specify the level of policy check to apply to cause failures.
+
+- Jan 20, 2021
+  - Added DETECT_VERSION so you can specify the version of Synopsys Detect.  However be aware that parameters change over time and so may not be compatible with the parameters being passed via submit_scans.sh.
 
 - Oct 2, 2019
   - Switching from scan.cli.sh to Synopsys Detect

--- a/src/hub_load/submit_scans.sh
+++ b/src/hub_load/submit_scans.sh
@@ -128,6 +128,7 @@ else
 fi
 
 if [ "${INSECURE_CURL}" == "yes" ]; then
+	echo "Setting environment variable DETECT_CURL_OPTS=--insecure"
 	export DETECT_CURL_OPTS=--insecure
 fi
 

--- a/src/hub_load/submit_scans.sh
+++ b/src/hub_load/submit_scans.sh
@@ -38,7 +38,6 @@ cd $WORKDIR
 #
 # Defaults
 #
-BD_TIMEOUT=${BD_TIMEOUT:-120}
 API_TIMEOUT=${API_TIMEOUT:-300}
 MAX_SCANS=${MAX_SCANS:-10}
 MAX_CODELOCATIONS=${MAX_CODELOCATIONS:-1}
@@ -49,6 +48,8 @@ SYNCHRONOUS_SCANS=${SYNCHRONOUS_SCANS:-yes}
 REPEAT_SCAN=${REPEAT_SCAN:-no}
 DETECT_VERSION=${DETECT_VERSION}
 FAIL_ON_SEVERITIES=${FAIL_ON_SEVERITIES}
+INSECURE_CURL=${INSECURE_CURL:-no}
+SNIPPET_MATCHING_MODE=${SNIPPET_MATCHING_MODE:-NONE}
 
 if [ -z "${DETECT_VERSION}" ]
 then
@@ -66,7 +67,7 @@ fi
 PROJECT="Project-$HOSTNAME"
 TIMESTAMP=$(date +%Y%m%d.%H%M%S)
 
-INT_PARAMS="BD_HUB_URL API_TOKEN BD_TIMEOUT API_TIMEOUT MAX_SCANS MAX_CODELOCATIONS MIN_COMPONENTS MAX_COMPONENTS MAX_VERSIONS REPEAT_SCAN SYNCHRONOUS_SCANS DETECT_VERSION FAIL_ON_SEVERITIES"
+INT_PARAMS="BD_HUB_URL API_TOKEN API_TIMEOUT MAX_SCANS MAX_CODELOCATIONS MIN_COMPONENTS MAX_COMPONENTS MAX_VERSIONS REPEAT_SCAN SYNCHRONOUS_SCANS DETECT_VERSION FAIL_ON_SEVERITIES INSECURE_CURL SNIPPET_MATCHING_MODE"
 
 if [ "$INTERACTIVE" = "yes" ]
 then
@@ -124,6 +125,10 @@ then
   echo "Using FAIL_ON_SEVERITIES ${FAIL_ON_SEVERITIES}"
 else 
   echo "Not specifying FAIL_ON_SEVERITIES"
+fi
+
+if [ "${INSECURE_CURL}" == "yes" ]; then
+	export DETECT_CURL_OPTS=--insecure
 fi
 
 #
@@ -205,11 +210,13 @@ do
       DETECT_OPTIONS="${DETECT_OPTIONS} --detect.project.name=${project_name} --detect.project.version.name=${v}"
       DETECT_OPTIONS="${DETECT_OPTIONS} --detect.code.location.name=${cl_name}"
       DETECT_OPTIONS="${DETECT_OPTIONS} --blackduck.trust.cert=true"
-      DETECT_OPTIONS="${DETECT_OPTIONS} --detect.report.timeout=${API_TIMEOUT}"
-      DETECT_OPTIONS="${DETECT_OPTIONS} --blackduck.timeout=${BD_TIMEOUT}"
+      DETECT_OPTIONS="${DETECT_OPTIONS} --detect.timeout=${API_TIMEOUT}"
       DETECT_OPTIONS="${DETECT_OPTIONS} --detect.parallel.processors=-1"
       DETECT_OPTIONS="${DETECT_OPTIONS} --detect.tools=SIGNATURE_SCAN"
       DETECT_OPTIONS="${DETECT_OPTIONS} --detect.source.path=${project_name}/${cl_name}"
+	  if [ "${SNIPPET_MATCHING_MODE}" != "NONE" ]; then
+        DETECT_OPTIONS="${DETECT_OPTIONS} --detect.blackduck.signature.scanner.snippet.matching=${SNIPPET_MATCHING_MODE}"
+      fi
       if [ "${SYNCHRONOUS_SCANS}" == "yes" ]; then
         DETECT_OPTIONS="${DETECT_OPTIONS} --detect.wait.for.results=true"
       fi
@@ -217,7 +224,7 @@ do
         DETECT_OPTIONS="${DETECT_OPTIONS} --detect.policy.check.fail.on.severities=${FAIL_ON_SEVERITIES}"
       fi
       detect_log=/tmp/detect_$$.log
-      bash <(curl -s -L https://detect.synopsys.com/detect.sh) ${DETECT_OPTIONS} | tee ${detect_log}
+      bash <(curl -s -L ${DETECT_CURL_OPTS} https://detect.synopsys.com/detect.sh) ${DETECT_OPTIONS} | tee ${detect_log}
       elapsed_time=$(get_elapsed_time $detect_log)
       echo "Elapsed time for scan was ${elapsed_time} seconds"
       rm $detect_log


### PR DESCRIPTION
A couple of simple changes and a more controversial one:

- Some users require that we set --insecure for Curl requests to download Detect and Detect requires this to have DETECT_CURL_OPTS=--insecure as an environment variable.  Made this a configurable option to avoid custom hub_load images in this scenario.
- Updated deprecated blackduck.timeout and detect.report.timeout so it does not break once the new Detect has been released.
- The most controversial part is the addition of snippet matching, added a new parameter that allows specifying the snippet matching mode but this will really increase the load on the Black Duck server.

I wanted to get your thoughts before putting the snippet matching change in